### PR TITLE
Issue-12 : Add k8s files

### DIFF
--- a/grafana/k8s/k8s-grafana-dashboards-configmap.yaml
+++ b/grafana/k8s/k8s-grafana-dashboards-configmap.yaml
@@ -1,0 +1,187 @@
+# Grafana ConfigMap for Flask dashboard
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-config
+  namespace: default
+data:
+  dashboard.yml: |
+    apiVersion: 1
+    providers:
+    - name: 'default'
+      orgId: 1
+      folder: ''
+      type: file
+      disableDeletion: false
+      updateIntervalSeconds: 10
+      allowUiUpdates: true
+      options:
+        path: /var/lib/grafana/dashboards
+  flask-dashboard.json: |
+    {
+      "id": null,
+      "title": "Flask Application Metrics",
+      "tags": ["flask", "python"],
+      "timezone": "browser",
+      "editable": true,
+      "schemaVersion": 27,
+      "version": 1,
+      "panels": [
+        {
+          "id": 1,
+          "title": "HTTP Request Rate",
+          "type": "stat",
+          "targets": [
+            {
+              "expr": "rate(flask_http_request_total[5m])",
+              "legendFormat": "{{method}} {{status}}",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps"
+            }
+          }
+        },
+        {
+          "id": 2,
+          "title": "HTTP Request Duration (95th percentile)",
+          "type": "stat",
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, rate(flask_http_request_duration_seconds_bucket[5m]))",
+              "legendFormat": "95th percentile",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s"
+            }
+          }
+        },
+        {
+          "id": 3,
+          "title": "HTTP Requests by Status Code",
+          "type": "timeseries",
+          "targets": [
+            {
+              "expr": "rate(flask_http_request_total[5m])",
+              "legendFormat": "{{status}} - {{method}}",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 8},
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps"
+            }
+          }
+        },
+        {
+          "id": 4,
+          "title": "Request Duration Histogram",
+          "type": "timeseries",
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, rate(flask_http_request_duration_seconds_bucket[5m]))",
+              "legendFormat": "50th percentile",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.90, rate(flask_http_request_duration_seconds_bucket[5m]))",
+              "legendFormat": "90th percentile",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, rate(flask_http_request_duration_seconds_bucket[5m]))",
+              "legendFormat": "99th percentile",
+              "refId": "C"
+            }
+          ],
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s"
+            }
+          }
+        },
+        {
+          "id": 5,
+          "title": "HTTP Exceptions",
+          "type": "timeseries",
+          "targets": [
+            {
+              "expr": "rate(flask_http_request_exceptions_total[5m])",
+              "legendFormat": "Exceptions",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 16},
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps"
+            }
+          }
+        },
+        {
+          "id": 6,
+          "title": "Total Requests",
+          "type": "stat",
+          "targets": [
+            {
+              "expr": "flask_http_request_total",
+              "legendFormat": "Total Requests",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 6, "w": 8, "x": 0, "y": 24},
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short"
+            }
+          }
+        },
+        {
+          "id": 7,
+          "title": "Average Request Duration",
+          "type": "stat",
+          "targets": [
+            {
+              "expr": "rate(flask_http_request_duration_seconds_sum[5m]) / rate(flask_http_request_duration_seconds_count[5m])",
+              "legendFormat": "Avg Duration",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 6, "w": 8, "x": 8, "y": 24},
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s"
+            }
+          }
+        },
+        {
+          "id": 8,
+          "title": "Request Rate",
+          "type": "stat",
+          "targets": [
+            {
+              "expr": "rate(flask_http_request_total[5m])",
+              "legendFormat": "Requests/sec",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 6, "w": 8, "x": 16, "y": 24},
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps"
+            }
+          }
+        }
+      ],
+      "time": {"from": "now-1h", "to": "now"},
+      "refresh": "5s"
+    }

--- a/grafana/k8s/k8s-grafana-datasources-configmap.yaml
+++ b/grafana/k8s/k8s-grafana-datasources-configmap.yaml
@@ -1,0 +1,16 @@
+# Grafana ConfigMap for datasource configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasource-config
+  namespace: default
+data:
+  datasource.yml: |
+    apiVersion: 1
+    datasources:
+    - name: Prometheus
+      type: prometheus
+      access: proxy
+      url: http://prometheus-service:9090
+      isDefault: true
+      editable: true

--- a/grafana/k8s/k8s-grafana-deployment.yaml
+++ b/grafana/k8s/k8s-grafana-deployment.yaml
@@ -1,0 +1,68 @@
+# Grafana Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-deployment
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: grafana/grafana:latest
+        ports:
+        - containerPort: 3000
+        env:
+        - name: GF_SECURITY_ADMIN_USER
+          valueFrom:
+            secretKeyRef:
+              name: grafana-admin-credentials
+              key: GF_ADMIN_USER
+        - name: GF_SECURITY_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: grafana-admin-credentials
+              key: GF_ADMIN_PASSWORD
+        - name: GF_INSTALL_PLUGINS
+          value: "grafana-piechart-panel"
+        volumeMounts:
+        - name: grafana-storage
+          mountPath: /var/lib/grafana
+        - name: grafana-datasource-config
+          mountPath: /etc/grafana/provisioning/datasources
+        - name: grafana-dashboard-config
+          mountPath: /etc/grafana/provisioning/dashboards
+        - name: grafana-dashboards
+          mountPath: /var/lib/grafana/dashboards
+        resources:
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+      volumes:
+      - name: grafana-storage
+        emptyDir: {}
+      - name: grafana-datasource-config
+        configMap:
+          name: grafana-datasource-config
+      - name: grafana-dashboard-config
+        configMap:
+          name: grafana-dashboard-config
+          items:
+          - key: dashboard.yml
+            path: dashboard.yml
+      - name: grafana-dashboards
+        configMap:
+          name: grafana-dashboard-config
+          items:
+          - key: flask-dashboard.json
+            path: flask-dashboard.json

--- a/grafana/k8s/k8s-grafana-secret.yaml
+++ b/grafana/k8s/k8s-grafana-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-admin-credentials
+type: Opaque
+stringData:
+  GF_ADMIN_USER: "admin"
+  GF_ADMIN_PASSWORD: "admin"

--- a/grafana/k8s/k8s-grafana-service.yaml
+++ b/grafana/k8s/k8s-grafana-service.yaml
@@ -1,0 +1,14 @@
+# Grafana Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-service
+  namespace: default
+spec:
+  selector:
+    app: grafana
+  ports:
+  - port: 3000
+    targetPort: 3000
+    nodePort: 32000
+  type: NodePort


### PR DESCRIPTION
Add Grafana's k8s files. The default user namd password are 'admin'. Of course, user should change them after first login.

The default datasource is the Prometheus pod (port 9090).

The file k8s-grafana-dashboards-configmap.yaml contain a dashboard with flask metrics. This is very nice. :)

Issue: #12

Signed-off-by: Yaakov Neuman <yakinew@yahoo.com>