### PR TITLE
Issue 19 : Fix BUG : fail to delete product after restock it

### DIFF
--- a/backend/src/controllers/products.py
+++ b/backend/src/controllers/products.py
@@ -5,7 +5,8 @@ import logging
 from connexion import NoContent
 import exceptions
 from controllers import tools
-from models.product import Product  # Import the new Product model
+from models.product import Product
+from models.restock_log import RestockLog
 
 LOG = logging.getLogger(__name__)
 
@@ -82,6 +83,10 @@ def product_update(product_id: int, body: dict):
 @tools.expected_errors(404)
 def product_delete(product_id: int):
     """Delete a product from the inventory."""
+    restock_logs = RestockLog.get_by_product_id(product_id)
+    for restock_log in restock_logs:
+        restock_log.delete()
+
     product = _get_product_by_id(product_id)
     product.delete()
     LOG.info('Product %s was deleted successfully!', product.id)

--- a/backend/src/models/restock_log.py
+++ b/backend/src/models/restock_log.py
@@ -4,11 +4,11 @@ SQLAlchemy model for RestockLog entity
 import logging
 from datetime import datetime
 from sqlalchemy import Column, Integer, Text, DateTime, ForeignKey
-# Assuming db_session from database.py as per user's model_base.py
 from db.database import Base
 from models.model_base import BaseModel
 
 LOG = logging.getLogger(__name__)
+
 
 class RestockLog(BaseModel, Base):
     """RestockLog model."""
@@ -36,3 +36,8 @@ class RestockLog(BaseModel, Base):
             'reason': self.reason,
             'restocked_at': self.restocked_at.isoformat() if self.restocked_at else None
         }
+
+    @classmethod
+    def get_by_product_id(cls, id_: int):
+        restock_log = cls.query.filter(cls.product_id == id_).all()  # pylint: disable=E1101
+        return restock_log


### PR DESCRIPTION
Add function to get the restock logs according to the product ID. We will use this function in the next commit to delete the logs when user deletes the product. Becuase the product ID in RestockLog is a ForeignKey, we cannot delete a product without deleting the restock logs first.

Issue: #19

Signed-off-by: Yaakov Neuman <yakinew@yahoo.com>